### PR TITLE
Augment travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: node_js
 node_js:
-  - "node"
+  - "10"
+  - "9"
+  - "8"
+script:
+  - npm ci
+  - npm run lint
+  - npm run coverage
 after_success:
-  - npm run coveralls
+  - cat ./coverage/lcov.info | coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,4 @@ node_js:
 script:
   - npm run lint
   - npm run coverage
-after_success:
   - cat ./coverage/lcov.info | coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ node_js:
   - "9"
   - "8"
 script:
-  - npm ci
   - npm run lint
   - npm run coverage
 after_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,13 @@
+environment:
+  matrix:
+    - nodejs_version: "8"
+    - nodejs_version: "9"
+    - nodejs_version: "10"
+install:
+  - ps: Install-Product node $env:nodejs_version
+  - npm install
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+build: off

--- a/package.json
+++ b/package.json
@@ -45,10 +45,9 @@
   "gitHead": "",
   "scripts": {
     "coverage": "nyc --reporter=html --reporter=text mocha --timeout 25000 --recursive test/unit",
-    "coveralls": "nyc --reporter=lcov mocha --timeout 40000 --recursive test/unit && cat ./coverage/lcov.info | coveralls",
-    "test": " mocha --timeout 5000 --recursive test/unit && npm run standard",
+    "lint": "standard",
     "precommit": "lint-staged",
-    "standard": "standard"
+    "test": " mocha --timeout 5000 --recursive test/unit && npm run lint"
   },
   "lint-staged": {
     "*.js": "standard"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "_from": "roosevelt-uglify@*",
   "gitHead": "",
   "scripts": {
-    "coverage": "nyc --reporter=html --reporter=text mocha --timeout 25000 --recursive test/unit",
+    "coverage": "nyc --reporter=html --reporter=text --reporter=lcov mocha --timeout 25000 --recursive test/unit",
     "lint": "standard",
     "precommit": "lint-staged",
     "test": " mocha --timeout 5000 --recursive test/unit && npm run lint"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "coverage": "nyc --reporter=html --reporter=text --reporter=lcov mocha --timeout 25000 --recursive test/unit",
     "lint": "standard",
     "precommit": "lint-staged",
-    "test": " mocha --timeout 5000 --recursive test/unit && npm run lint"
+    "test": "npm run lint && mocha --timeout 25000 --recursive test/unit"
   },
   "lint-staged": {
     "*.js": "standard"


### PR DESCRIPTION
- Test on node versions 8-10
- Use the coverage script as the test script (No more running tests twice)
- ~~Test out the new `npm ci` feature. (Let's hope it works!)~~ [It didn't]
- Cleanup NPM scripts